### PR TITLE
Updates from main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 The Snowfork fork of Alex Stoke's SSZ lib, mainly to pin the `bitvec` crate to a version compatible with the Substrate `bitvec` version (`0.20.*`). It also supports running in a no-std environment.
 
-# ssz_rs ✂️
 # ssz-rs ✂️️
 
 [![build](https://github.com/ralexstokes/ssz-rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/ralexstokes/ssz-rs/actions/workflows/rust.yml)

--- a/ssz-rs/Cargo.toml
+++ b/ssz-rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ssz-rs"
 version = "0.8.0"
+rust-version = "1.60"
 authors = ["Alex Stokes <r.alex.stokes@gmail.com>", "Clara van Staden <clara@snowfork.com>"]
 edition = "2021"
 license = "MIT"
@@ -14,13 +15,26 @@ exclude = [
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["serde", "std"]
+std = [
+    "bitvec/std",
+    "sha2/std",
+    "lazy_static/spin",
+    "num-bigint/std",
+    "serde/std",
+    # "hex/std"
+]
+serde = ["dep:serde", "dep:hex"]
+
 [dependencies]
+thiserror = "1.0.25"
 bitvec = { version = "1.0.0", default-features = false, features=["alloc"]}
 ssz-rs-derive = { path = "../ssz-rs-derive"}
 sha2 = { version ="0.9.8", default-features = false}
 lazy_static = { version = "1.4.0", features=["spin_no_std"]}
-serde = { version = "1.0", features = ["derive"], optional = true }
-hex = {version = "0.4.3", optional = true }
+serde = { version = "1.0", features = ["derive"], optional=true }
+hex = {version = "0.4.3", optional=true }
 num-bigint = { version ="0.4.3", default-features = false}
 
 [dev-dependencies]
@@ -28,18 +42,3 @@ hex-literal = "0.3.3"
 snap = "1.0"
 project-root = "0.2.2"
 serde_json = "1.0.81"
-
-[features]
-default = ["std", "serde-rs"]
-std = [
-    "bitvec/std",
-    "sha2/std",
-    "lazy_static/spin",
-    "num-bigint/std",
-    "serde/std",
-    "hex/std"
-]
-serde-rs = [
-    "serde",
-    "hex"
-]

--- a/ssz-rs/src/bitlist.rs
+++ b/ssz-rs/src/bitlist.rs
@@ -13,7 +13,7 @@ type BitlistInner = BitVec<u8, Lsb0>;
 #[derive(PartialEq, Eq, Clone)]
 pub struct Bitlist<const N: usize>(BitlistInner);
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<const N: usize> serde::Serialize for Bitlist<N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -28,7 +28,7 @@ impl<const N: usize> serde::Serialize for Bitlist<N> {
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de, const N: usize> serde::Deserialize<'de> for Bitlist<N> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/ssz-rs/src/bitvector.rs
+++ b/ssz-rs/src/bitvector.rs
@@ -20,7 +20,7 @@ type BitvectorInner = BitVec<u8, Lsb0>;
 #[derive(PartialEq, Eq, Clone)]
 pub struct Bitvector<const N: usize>(BitvectorInner);
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<const N: usize> serde::Serialize for Bitvector<N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -34,7 +34,7 @@ impl<const N: usize> serde::Serialize for Bitvector<N> {
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de, const N: usize> serde::Deserialize<'de> for Bitvector<N> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -14,7 +14,7 @@ mod de;
 mod list;
 mod merkleization;
 mod ser;
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 mod serde_test;
 mod uint;
 mod union;

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -5,10 +5,10 @@ use crate::merkleization::{
 };
 use crate::ser::{serialize_composite, Serialize, SerializeError};
 use crate::{SimpleSerialize, Sized};
-use crate::std::{Enumerate, FromIterator, vec, Vec, fmt, SliceIndex, Deref, Index, IndexMut, IterMut as StdIterMut, Debug, Display, Formatter};
-#[cfg(feature = "serde-rs")]
+use crate::std::{Enumerate, FromIterator, vec, Vec, fmt, SliceIndex, Deref, Index, IndexMut, IterMut as StdIterMut, Debug, Display, Formatter, any};
+#[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 use std::marker::PhantomData;
 
 pub enum ListError {
@@ -35,7 +35,7 @@ pub struct List<T: SimpleSerialize, const N: usize> {
 }
 
 // TODO clean up impls here for Vector and List...
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<T: SimpleSerialize + serde::Serialize, const N: usize> serde::Serialize for List<T, N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -49,10 +49,10 @@ impl<T: SimpleSerialize + serde::Serialize, const N: usize> serde::Serialize for
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 struct ListVisitor<T: SimpleSerialize>(PhantomData<Vec<T>>);
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de, T: SimpleSerialize + serde::Deserialize<'de>> serde::de::Visitor<'de> for ListVisitor<T> {
     type Value = Vec<T>;
 
@@ -68,7 +68,7 @@ impl<'de, T: SimpleSerialize + serde::Deserialize<'de>> serde::de::Visitor<'de> 
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de, T: SimpleSerialize + serde::de::Deserialize<'de>, const N: usize> serde::Deserialize<'de>
     for List<T, N>
 {
@@ -96,7 +96,7 @@ where
             write!(
                 f,
                 "List<{}, {}>(len={}){:#?}",
-                std::any::type_name::<T>(),
+                any::type_name::<T>(),
                 N,
                 self.len(),
                 self.data
@@ -105,7 +105,7 @@ where
             write!(
                 f,
                 "List<{}, {}>(len={}){:?}",
-                std::any::type_name::<T>(),
+                any::type_name::<T>(),
                 N,
                 self.len(),
                 self.data

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -92,7 +92,25 @@ where
     T: SimpleSerialize + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "List<len={}, cap={}>{:?}", self.len(), N, self.data)
+        if f.alternate() {
+            write!(
+                f,
+                "List<{}, {}>(len={}){:#?}",
+                std::any::type_name::<T>(),
+                N,
+                self.len(),
+                self.data
+            )
+        } else {
+            write!(
+                f,
+                "List<{}, {}>(len={}){:?}",
+                std::any::type_name::<T>(),
+                N,
+                self.len(),
+                self.data
+            )
+        }
     }
 }
 

--- a/ssz-rs/src/merkleization/mod.rs
+++ b/ssz-rs/src/merkleization/mod.rs
@@ -15,9 +15,6 @@ pub(crate) const BYTES_PER_CHUNK: usize = 32;
 
 pub trait Merkleized {
     // Compute the "hash tree root" of `Self`.
-    // Note: the `Context` can be re-used across all calls to this function
-    // across all types. One `Context` can be safely used across the entire
-    // lifetime of your program.
     fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError>;
 }
 

--- a/ssz-rs/src/merkleization/node.rs
+++ b/ssz-rs/src/merkleization/node.rs
@@ -4,7 +4,7 @@ use crate::std::{Index, IndexMut, Vec, vec, TryFromSliceError, fmt, AsRef};
 #[derive(Default, Clone, Copy, PartialEq, Eq, SimpleSerialize)]
 pub struct Node(pub(crate) [u8; 32]);
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl serde::Serialize for Node {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -14,7 +14,7 @@ impl serde::Serialize for Node {
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Node {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/ssz-rs/src/std.rs
+++ b/ssz-rs/src/std.rs
@@ -7,9 +7,9 @@
 // copied, modified, or distributed except according to those terms.
 
 #[cfg(feature = "std")]
-pub use std::{array::TryFromSliceError, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, default::Default, fmt, fmt::Debug, fmt::Display, fmt::Formatter, iter::FromIterator, iter::Enumerate, ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, option::Option, slice::IterMut, slice::SliceIndex, vec, vec::Vec};
+pub use std::{array::TryFromSliceError, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, default::Default, fmt, fmt::Debug, fmt::Display, fmt::Formatter, iter::FromIterator, iter::Enumerate, ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, option::Option, slice::IterMut, slice::SliceIndex, vec, vec::Vec, any};
 
 #[cfg(not(feature = "std"))]
 pub use alloc::{vec, vec::Vec};
 #[cfg(not(feature = "std"))]
-pub use core::{array::TryFromSliceError, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, default::Default, fmt, fmt::Debug, fmt::Display, fmt::Formatter, iter::Enumerate, iter::FromIterator, ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, option::Option, slice::IterMut, slice::SliceIndex};
+pub use core::{array::TryFromSliceError, cmp::Ordering, convert::AsRef, convert::TryFrom, convert::TryInto, default::Default, fmt, fmt::Debug, fmt::Display, fmt::Formatter, iter::Enumerate, iter::FromIterator, ops::DerefMut, ops::Deref, ops::Index, ops::IndexMut, option::Option, slice::IterMut, slice::SliceIndex, any};

--- a/ssz-rs/src/uint.rs
+++ b/ssz-rs/src/uint.rs
@@ -73,6 +73,10 @@ impl U256 {
         Self(BigUint::default())
     }
 
+    pub fn zero() -> Self {
+        Self::default()
+    }
+
     pub fn try_from_bytes_le(bytes: &[u8]) -> Result<Self, DeserializeError> {
         Self::deserialize(bytes)
     }
@@ -85,6 +89,12 @@ impl U256 {
         let mut bytes = self.0.to_bytes_le();
         bytes.resize(32, 0u8);
         bytes
+    }
+}
+
+impl From<u64> for U256 {
+    fn from(x: u64) -> Self {
+        Self(x.into())
     }
 }
 

--- a/ssz-rs/src/uint.rs
+++ b/ssz-rs/src/uint.rs
@@ -98,7 +98,7 @@ impl From<u64> for U256 {
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl serde::Serialize for U256 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -109,7 +109,7 @@ impl serde::Serialize for U256 {
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for U256 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -120,7 +120,23 @@ where
     T: SimpleSerialize + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "Vector<{}>{:?}", N, self.data)
+        if f.alternate() {
+            write!(
+                f,
+                "Vector<{}, {}>{:#?}",
+                std::any::type_name::<T>(),
+                N,
+                self.data
+            )
+        } else {
+            write!(
+                f,
+                "Vector<{}, {}>{:?}",
+                std::any::type_name::<T>(),
+                N,
+                self.data
+            )
+        }
     }
 }
 

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -4,10 +4,10 @@ use crate::merkleization::{
 };
 use crate::ser::{serialize_composite, Serialize};
 use crate::{SerializeError, SimpleSerialize, Sized};
-use crate::std::{Vec, vec, SliceIndex, IndexMut, Index, Deref, TryFrom, fmt, Debug, Display, Formatter};
-#[cfg(feature = "serde-rs")]
+use crate::std::{Vec, vec, SliceIndex, IndexMut, Index, Deref, TryFrom, fmt, Debug, Display, Formatter, any};
+#[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 use std::marker::PhantomData;
 
 pub enum VectorError {
@@ -34,7 +34,7 @@ impl Display for VectorError {
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<T: SimpleSerialize + serde::Serialize, const N: usize> serde::Serialize for Vector<T, N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -48,10 +48,10 @@ impl<T: SimpleSerialize + serde::Serialize, const N: usize> serde::Serialize for
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 struct VectorVisitor<T: SimpleSerialize>(PhantomData<Vec<T>>);
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de, T: SimpleSerialize + serde::Deserialize<'de>> serde::de::Visitor<'de>
     for VectorVisitor<T>
 {
@@ -69,7 +69,7 @@ impl<'de, T: SimpleSerialize + serde::Deserialize<'de>> serde::de::Visitor<'de>
     }
 }
 
-#[cfg(feature = "serde-rs")]
+#[cfg(feature = "serde")]
 impl<'de, T: SimpleSerialize + serde::de::Deserialize<'de>, const N: usize> serde::Deserialize<'de>
     for Vector<T, N>
 {
@@ -124,7 +124,7 @@ where
             write!(
                 f,
                 "Vector<{}, {}>{:#?}",
-                std::any::type_name::<T>(),
+                any::type_name::<T>(),
                 N,
                 self.data
             )
@@ -132,7 +132,7 @@ where
             write!(
                 f,
                 "Vector<{}, {}>{:?}",
-                std::any::type_name::<T>(),
+                any::type_name::<T>(),
                 N,
                 self.data
             )


### PR DESCRIPTION
- Pulls from https://github.com/ralexstokes/ssz-rs `main`.
- Fixes readme typo.
- Updates cargo.toml to match upstream repo.
- Renames `serde-rs` back to `serde` now that namespaced Cargo features are stable.