### PR TITLE
Fixes failure tests resulting in stack overflow error.

### DIFF
--- a/ssz-rs/src/de.rs
+++ b/ssz-rs/src/de.rs
@@ -2,6 +2,7 @@ use crate::ser::BYTES_PER_LENGTH_OFFSET;
 use crate::SimpleSerialize;
 use crate::std::{Vec, vec, Debug, Display, Formatter};
 
+#[derive(Debug)]
 pub enum DeserializeError {
     InputTooShort,
     ExtraInput,
@@ -11,15 +12,16 @@ pub enum DeserializeError {
     IllegalType { bound: usize },
 }
 
-impl Debug for DeserializeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
 impl Display for DeserializeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self)
+        match *self {
+            DeserializeError::InputTooShort => write!(f, "InputTooShort"),
+            DeserializeError::ExtraInput => write!(f, "ExtraInput"),
+            DeserializeError::InvalidInput => write!(f, "InvalidInput"),
+            DeserializeError::IOError => write!(f, "IOError"),
+            DeserializeError::TypeBoundsViolated { bound, len } => write!(f, "TypeBoundsViolated bound: {} len {}", bound, len),
+            DeserializeError::IllegalType { bound } => write!(f, "IllegalType bound: {}", bound),
+        }
     }
 }
 

--- a/ssz-rs/tests/basic_vector.rs
+++ b/ssz-rs/tests/basic_vector.rs
@@ -22175,7 +22175,6 @@ fn test_basic_vector_vec_uint32_3_zero() {
     assert_eq!(root, expected_root);
 }
 
-/*
 #[test]
 #[should_panic]
 fn test_basic_vector_vec_uint16_2_max_one_byte_less() {
@@ -30018,4 +30017,3 @@ fn test_basic_vector_vec_uint16_3_nil() {
 
     deserialize::<Vector<u16, 3>>(&encoding);
 }
-*/

--- a/ssz-rs/tests/bitlist.rs
+++ b/ssz-rs/tests/bitlist.rs
@@ -5507,7 +5507,6 @@ fn test_bitlist_bitlist_1_zero_4() {
     assert_eq!(root, expected_root);
 }
 
-/*
 #[test]
 #[should_panic]
 fn test_bitlist_bitlist_1_but_2() {
@@ -5647,4 +5646,3 @@ fn test_bitlist_bitlist_no_delimiter_zeroes() {
 
     deserialize::<Bitlist<256>>(&encoding);
 }
-*/

--- a/ssz-rs/tests/bitvector.rs
+++ b/ssz-rs/tests/bitvector.rs
@@ -799,7 +799,6 @@ fn test_bitvector_bitvec_8_max() {
     assert_eq!(root, expected_root);
 }
 
-/*
 #[test]
 #[should_panic]
 fn test_bitvector_bitvec_9_max_8() {
@@ -1109,4 +1108,3 @@ fn test_bitvector_bitvec_16_random_8() {
 
     deserialize::<Bitvector<16>>(&encoding);
 }
-*/

--- a/ssz-rs/tests/boolean.rs
+++ b/ssz-rs/tests/boolean.rs
@@ -41,7 +41,6 @@ fn test_boolean_false() {
     assert_eq!(root, expected_root);
 }
 
-/*
 #[test]
 #[should_panic]
 fn test_boolean_byte_0x80() {
@@ -80,4 +79,4 @@ fn test_boolean_byte_rev_nibble() {
     );
 
     deserialize::<bool>(&encoding);
-}*/
+}

--- a/ssz-rs/tests/containers.rs
+++ b/ssz-rs/tests/containers.rs
@@ -22202,7 +22202,6 @@ fn test_containers_bits_struct_one_chaos_2() {
     assert_eq!(root, expected_root);
 }
 
-/*
 #[test]
 #[should_panic]
 fn test_containers_bits_struct_offset_6_zeroed() {
@@ -22386,4 +22385,3 @@ fn test_containers_complex_test_struct_extra_byte() {
 
     deserialize::<ComplexTestStruct>(&encoding);
 }
-*/

--- a/ssz-rs/tests/uints.rs
+++ b/ssz-rs/tests/uints.rs
@@ -1781,7 +1781,6 @@ fn test_uints_uint_64_last_byte_empty() {
     assert_eq!(root, expected_root);
 }
 
-/*
 #[test]
 #[should_panic]
 fn test_uints_uint_128_one_too_high() {
@@ -1960,4 +1959,4 @@ fn test_uints_uint_8_one_byte_shorter() {
     );
 
     deserialize::<u8>(&encoding);
-}*/
+}


### PR DESCRIPTION
The root cause of the test failures was that the Display impl for DeserializeError caused a stack overflow. An issue explaining: https://github.com/rust-lang/rust/issues/45838