### PR TITLE
Change error messages back to what they were.

### DIFF
--- a/ssz-rs/src/de.rs
+++ b/ssz-rs/src/de.rs
@@ -15,12 +15,12 @@ pub enum DeserializeError {
 impl Display for DeserializeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match *self {
-            DeserializeError::InputTooShort => write!(f, "InputTooShort"),
-            DeserializeError::ExtraInput => write!(f, "ExtraInput"),
-            DeserializeError::InvalidInput => write!(f, "InvalidInput"),
+            DeserializeError::InputTooShort => write!(f, "expected further data when decoding"),
+            DeserializeError::ExtraInput => write!(f, "unexpected additional data provided when decoding"),
+            DeserializeError::InvalidInput => write!(f, "invalid data for expected type"),
             DeserializeError::IOError => write!(f, "IOError"),
-            DeserializeError::TypeBoundsViolated { bound, len } => write!(f, "TypeBoundsViolated bound: {} len {}", bound, len),
-            DeserializeError::IllegalType { bound } => write!(f, "IllegalType bound: {}", bound),
+            DeserializeError::TypeBoundsViolated { bound, len } => write!(f, "the type for this value has a bound of {} but the value has {} elements", bound, len),
+            DeserializeError::IllegalType { bound } => write!(f, "the type for this value has an illegal bound of {}", bound),
         }
     }
 }

--- a/ssz-rs/src/merkleization/mod.rs
+++ b/ssz-rs/src/merkleization/mod.rs
@@ -3,7 +3,7 @@ mod node;
 mod proofs;
 
 use crate::ser::{Serialize};
-use crate::std::{Index, Vec, vec, Option, Debug, Ordering, fmt};
+use crate::std::{Index, Vec, vec, Option, Debug, Ordering, fmt, Display, Formatter};
 use lazy_static::lazy_static;
 use sha2::{Digest, Sha256};
 
@@ -23,6 +23,16 @@ pub enum MerkleizationError {
     SerializationError, // failed to serialize value
     PartialChunk(Vec<u8>, usize), // cannot merkleize a partial chunk of length {1} (data: {0:?})
     InputExceedsLimit(usize), // cannot merkleize data that exceeds the declared limit {0}
+}
+
+impl Display for MerkleizationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            MerkleizationError::SerializationError => write!(f, "failed to serialize value"),
+            MerkleizationError::PartialChunk(chunk, size) => write!(f, "cannot merkleize a partial chunk of length {} (data: {:?}", size, chunk),
+            MerkleizationError::InputExceedsLimit(size) => write!(f, "cannot merkleize data that exceeds the declared limit: {}", size),
+        }
+    }
 }
 
 pub fn pack_bytes(buffer: &mut Vec<u8>) {

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -10,6 +10,7 @@ use serde::ser::SerializeSeq;
 #[cfg(feature = "serde")]
 use std::marker::PhantomData;
 
+#[derive(Debug)]
 pub enum VectorError {
     IncorrectLength { expected: usize, provided: usize }, // incorrect number of elements {provided} to make a Vector of length {expected}
 }
@@ -22,15 +23,11 @@ pub struct Vector<T: SimpleSerialize, const N: usize> {
     cache: MerkleCache,
 }
 
-impl Debug for VectorError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
 impl Display for VectorError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self)
+        match *self {
+            VectorError::IncorrectLength{ expected, provided } => write!(f, "incorrect number of elements {} to make a Vector of length {}", provided, expected),
+        }
     }
 }
 


### PR DESCRIPTION
Change error messages to match upstream crate.