### PR TITLE
Enable `serde` feature in no_std

### DIFF
--- a/ssz-rs/src/lib.rs
+++ b/ssz-rs/src/lib.rs
@@ -48,7 +48,7 @@ mod lib {
     pub use self::iter::Enumerate;
 
     #[cfg(not(feature = "std"))]
-    pub use alloc::{vec, vec::Vec};
+    pub use alloc::{format, string::String, vec, vec::Vec};
 
     #[cfg(feature = "std")]
     pub use std::vec::Vec;

--- a/ssz-rs/src/list.rs
+++ b/ssz-rs/src/list.rs
@@ -9,7 +9,7 @@ use crate::{SimpleSerialize, SimpleSerializeError, Sized};
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
 #[cfg(feature = "serde")]
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[derive(Debug)]
 pub enum ListError {

--- a/ssz-rs/src/vector.rs
+++ b/ssz-rs/src/vector.rs
@@ -8,7 +8,7 @@ use crate::{SerializeError, SimpleSerialize, SimpleSerializeError, Sized};
 #[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
 #[cfg(feature = "serde")]
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[derive(Debug)]
 pub enum VectorError {


### PR DESCRIPTION
Hi there, 

Since the `serde` feature depends on std, compiling in no_std fails.
I've made a PR to this branch because I was aware of [your upstream PR](https://github.com/ralexstokes/ssz-rs/pull/25 ), but please let me know if it is not appropriate.

Signed-off-by: Jun Kimura <junkxdev@gmail.com>